### PR TITLE
digitalocean: remove invalid chars from deploy template name

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,5 +1,5 @@
 spec:
-  name: Voltage Auto-Unlock
+  name: voltage-unlock
 
   services:
   - name: service


### PR DESCRIPTION
Remediates this error:
```
Could not create app from Git template.

Error validating app spec field "name": name in body should match '^[a-z][a-z0-9-]{0,30}[a-z0-9]$'.
```

Feel free to edit the new string. Basically anything w/o spaces or uppercase.

---

Here's a branch to validate this 1-line change results in a working DO button:
- [README.md @ thinkmassive/digitalocean-deploy-name-demo](https://github.com/thinkmassive/voltageautounlock/tree/digitalocean-deploy-name-demo#voltage-autounlock-webhook-service)