### PR TITLE
handler: update SecretHeader to match new webhook payload

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	SecretHeader  = "VOLTAGE_SECRET"
+	SecretHeader  = "Voltage-Secret"
 	Status        = "status"
 	WaitingUnlock = "waiting_unlock"
 	LNDUnlockPath = "/v1/unlockwallet"


### PR DESCRIPTION
The header was changed to not use an underscore.
https://docs.voltage.cloud/developers/webhooks#example-automatic-unlock